### PR TITLE
Fix instructions for clingwrapper installation

### DIFF
--- a/doc/source/repositories.rst
+++ b/doc/source/repositories.rst
@@ -84,7 +84,7 @@ the first step if you already cloned the repo for ``cppyy-cling``)::
 
  $ git clone https://github.com/wlav/cppyy-backend.git
  $ cd cppyy-backend/clingwrapper
- $ python -m pip install . --upgrade
+ $ python -m pip install . --upgrade --no-use-pep517 --no-deps
 
 Upgrading ``CPyCppyy`` (if on CPython; it's not needed for PyPy) and ``cppyy``
 is very similar::


### PR DESCRIPTION
As discussed on [172](https://bitbucket.org/wlav/cppyy/issues/172/anonymous-structs), installing clingwrapper from source fails with the following stacktrace:

```
src/clingwrapper.cxx:2001:26: error: no member named 'GetTagDeclId' in 'CppyyLegacy::TDataMember'; did you mean 'GetDeclId'?
          auto declid = m->GetTagDeclId();
                           ^~~~~~~~~~~~
                           GetDeclId
```

Updating the installation instructions to not use PEP 517 fixes the setup.