### PR TITLE
Remove references to Python 2 in preparation for the release of Root 6.32

### DIFF
--- a/bench/bench_functioncalls.py
+++ b/bench/bench_functioncalls.py
@@ -16,8 +16,6 @@ all_configs = [('py', 'py_functioncalls'), ('cppyy', 'cppyy.gbl')]
 N = 10000
 preamble = "@pytest.mark.benchmark(group=group, warmup=True)"
 looprange = range
-if sys.hexversion < 0x3000000:
-    looprange = xrange
 
 try:
     import __pypy__

--- a/bench/py_runvector.py
+++ b/bench/py_runvector.py
@@ -1,10 +1,8 @@
-import array, sys
+import array
 
 N = 100000000 # 10^8
 
 
 #- group: stl-vector ---------------------------------------------------------
 looprange = range
-if sys.hexversion < 0x3000000:
-    looprange = xrange
 global_vector = array.array('i', looprange(N))

--- a/bench/support.py
+++ b/bench/support.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import py, sys, subprocess
 
 currpath = py.path.local(__file__).dirpath()

--- a/doc/tutorial/CppyyTutorial.ipynb
+++ b/doc/tutorial/CppyyTutorial.ipynb
@@ -474,21 +474,21 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 2",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "python2"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.16"
+   "pygments_lexer": "ipython3",
+   "version": "3"
   }
  },
  "nbformat": 4,

--- a/doc/tutorial/GSLPythonizationTutorial.ipynb
+++ b/doc/tutorial/GSLPythonizationTutorial.ipynb
@@ -180,21 +180,21 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 2",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "python2"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.14"
+   "pygments_lexer": "ipython3",
+   "version": "3"
   }
  },
  "nbformat": 4,

--- a/python/cppyy/_cpython_cppyy.py
+++ b/python/cppyy/_cpython_cppyy.py
@@ -27,32 +27,6 @@ import ctypes
 _w = ctypes.CDLL(_backend.__file__, ctypes.RTLD_GLOBAL)
 
 
-# some beautification for inspect (only on p2)
-import sys
-if sys.hexversion < 0x3000000:
-  # TODO: this reliese on CPPOverload cooking up a func_code object, which atm
-  # is simply not implemented for p3 :/
-
-  # convince inspect that cppyy method proxies are possible drop-ins for python
-  # methods and classes for pydoc
-    import inspect
-
-    inspect._old_isfunction = inspect.isfunction
-    def isfunction(object):
-        if type(object) == _backend.CPPOverload and not object.im_class:
-            return True
-        return inspect._old_isfunction(object)
-    inspect.isfunction = isfunction
-
-    inspect._old_ismethod = inspect.ismethod
-    def ismethod(object):
-        if type(object) == _backend.CPPOverload:
-            return True
-        return inspect._old_ismethod(object)
-    inspect.ismethod = ismethod
-    del isfunction, ismethod
-
-
 ### template support ---------------------------------------------------------
 class Template(object):  # expected/used by ProxyWrappers.cxx in CPyCppyy
     stl_sequence_types   = ['std::vector', 'std::list', 'std::set', 'std::deque']

--- a/python/cppyy/_typemap.py
+++ b/python/cppyy/_typemap.py
@@ -2,8 +2,6 @@
     for typedef-ed C++ builtin types.
 """
 
-import sys
-
 def _create_mapper(cls, extra_dct=None):
     def mapper(name, scope):
         if scope:
@@ -76,20 +74,14 @@ def initialize(backend):
     str_tm = _create_mapper(str)
     for tp in ['char', 'unsigned char', 'signed char']:
         tm[tp] = str_tm
-    if sys.hexversion < 0x3000000:
-        tm['wchar_t'] = _create_mapper(unicode)
-    else:
         tm['wchar_t'] = str_tm
 
     # integer types
     int_tm = _create_mapper(int)
     for tp in ['int8_t', 'uint8_t', 'short', 'unsigned short', 'int']:
         tm[tp] = int_tm
-
-    if sys.hexversion < 0x3000000:
-        long_tm = _create_mapper(long)
-    else:
         long_tm = tm['int']
+
     for tp in ['unsigned int', 'long', 'unsigned long', 'long long', 'unsigned long long']:
         tm[tp] = long_tm
 

--- a/test/bindexplib.py
+++ b/test/bindexplib.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import os, sys, subprocess
 
 target = sys.argv[1]
@@ -29,4 +27,3 @@ for line in stdout.split('\r\n'):
     elif parts[4] == '()' and parts[5] == 'External':
         if isokay(parts[7]):
             outf.write('\t%s\n' % parts[7])
-

--- a/test/support.py
+++ b/test/support.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import os, py, sys, subprocess
 
 currpath = py.path.local(__file__).dirpath()
@@ -15,14 +14,10 @@ def setup_make(targetname):
     if popen.returncode:
         raise OSError("'make' failed:\n%s" % (stdout,))
 
-if sys.hexversion >= 0x3000000:
-    pylong = int
-    pyunicode = str
-    maxvalue = sys.maxsize
-else:
-    pylong = long
-    pyunicode = unicode
-    maxvalue = sys.maxint
+
+pylong = int
+pyunicode = str
+maxvalue = sys.maxsize
 
 IS_WINDOWS = 0
 if 'win32' in sys.platform:

--- a/test/test_cpp11features.py
+++ b/test/test_cpp11features.py
@@ -223,10 +223,7 @@ class TestCPP11FEATURES:
             i2 = T(i1)  # cctor
             assert T.s_move_counter == 0
 
-            if ispypy or 0x3000000 <= sys.hexversion:
-                i3 = T(std.move(T()))            # can't check ref-count
-            else:
-                i3 = T(T()) # should call move, not memoized cctor
+            i3 = T(T()) # should call move, not memoized cctor
             assert T.s_move_counter == 1
 
             i3 = T(std.move(T()))                # both move and ref-count
@@ -239,10 +236,7 @@ class TestCPP11FEATURES:
             i4.__assign__(i2)
             assert T.s_move_counter == 3
 
-            if ispypy or 0x3000000 <= sys.hexversion:
-                i4.__assign__(std.move(T()))     # can't check ref-count
-            else:
-                i4.__assign__(T())
+            i4.__assign__(T())
             assert T.s_move_counter == 4
 
             i4.__assign__(std.move(i2))

--- a/test/test_datatypes.py
+++ b/test/test_datatypes.py
@@ -1245,10 +1245,7 @@ class TestDATATYPES:
         buf = b'123456789'
         total = 0
         for c in buf:
-            try:
-                total += ord(c)        # p2
-            except TypeError:
-                total += c             # p3
+            total += c
 
         def run(self, f, buf, total):
 

--- a/test/test_lowlevel.py
+++ b/test/test_lowlevel.py
@@ -130,9 +130,8 @@ class TestLOWLEVEL:
         i = array('I', [0]);     ctd.set_uint_r(i);   assert i[0] ==  4
         i = array('l', [0]);     ctd.set_long_r(i);   assert i[0] == -5
         i = array('L', [0]);     ctd.set_ulong_r(i);  assert i[0] ==  6
-        if sys.hexversion >= 0x3000000:
-            i = array('q', [0]); ctd.set_llong_r(i);  assert i[0] == -7
-            i = array('Q', [0]); ctd.set_ullong_r(i); assert i[0] ==  8
+        i = array('q', [0]); ctd.set_llong_r(i);  assert i[0] == -7
+        i = array('Q', [0]); ctd.set_ullong_r(i); assert i[0] ==  8
 
       # floating point types
         f = array('f', [0]);     ctd.set_float_r(f);  assert f[0] ==  5.
@@ -158,11 +157,11 @@ class TestLOWLEVEL:
         # c_short           short                                       int
         # c_ushort          unsigned short                              int
         # c_int             int                                         int
-        # c_uint            unsigned int                                int/long
-        # c_long            long                                        int/long
-        # c_ulong           unsigned long                               int/long
-        # c_longlong        __int64 or long long                        int/long
-        # c_ulonglong       unsigned __int64 or unsigned long long      int/long
+        # c_uint            unsigned int                                int
+        # c_long            long                                        int
+        # c_ulong           unsigned long                               int
+        # c_longlong        __int64 or long long                        int
+        # c_ulonglong       unsigned __int64 or unsigned long long      int
         #
         # c_float           float                                       float
         # c_double          double                                      float
@@ -298,7 +297,7 @@ class TestLOWLEVEL:
         # ------------------------------------------------------------------------------
         # c_char_p          char* (NULL terminated)                     string or None
         # c_wchar_p         wchar_t* (NULL terminated)                  unicode or None
-        # c_void_p          void*                                       int/long or None
+        # c_void_p          void*                                       int or None
 
         import cppyy, ctypes
 

--- a/test/test_regression.py
+++ b/test/test_regression.py
@@ -1,4 +1,4 @@
-import os, sys
+import os
 from pytest import raises, skip
 from .support import setup_make, IS_WINDOWS, ispypy
 
@@ -86,11 +86,7 @@ class TestREGRESSION:
         import sysconfig as sc
 
         cppyy.add_include_path(sc.get_config_var("INCLUDEPY"))
-        if sys.hexversion < 0x3000000:
-            cppyy.cppdef("#undef _POSIX_C_SOURCE")
-            cppyy.cppdef("#undef _XOPEN_SOURCE")
-        else:
-            cppyy.cppdef("#undef slots")     # potentially pulled in by Qt/xapian.h
+        cppyy.cppdef("#undef slots")     # potentially pulled in by Qt/xapian.h
 
         cppyy.cppdef("""#include "Python.h"
            long py2long(PyObject* obj) { return PyLong_AsLong(obj); }""")

--- a/test/test_stltypes.py
+++ b/test/test_stltypes.py
@@ -35,7 +35,6 @@ class IterFunc:
         v = self.seqn[self.i]
         self.i += 1
         return v
-    next = __next__ # p2.7
 
 class IterGen:
     """Sequence using iterator protocol defined with a generator"""
@@ -56,7 +55,6 @@ class IterNextOnly:
         v = self.seqn[self.i]
         self.i += 1
         return v
-    next = __next__ # p2.7
 
 class IterNoNext:
     """Iterator missing __next__()"""
@@ -75,7 +73,6 @@ class IterGenExc:
         return self
     def __next__(self):
         3 // 0
-    next = __next__ # p2.7
 
 class IterFuncStop:
     """Test immediate stop"""
@@ -85,7 +82,6 @@ class IterFuncStop:
         return self
     def __next__(self):
         raise StopIteration
-    next = __next__ # p2.7
 
 from itertools import chain
 def itermulti(seqn):

--- a/test/test_templates.py
+++ b/test/test_templates.py
@@ -45,10 +45,7 @@ class TestTEMPLATES:
         assert m.get_size[int]()      == m.get_int_size()
 
       # specialized
-        if sys.hexversion >= 0x3000000:
-            targ = 'long'
-        else:
-            targ = long
+        targ = 'long'
         assert m.get_size[targ]()     == m.get_long_size()
 
         import ctypes


### PR DESCRIPTION
Support for Python 2 will be dropped in Root version 6.32. Please see https://github.com/root-project/root/issues/13861. The purpose of this PR is to make updating Root easier.