### PR TITLE
Remove Windows workaround for `std::endl` that is not needed anymore

### DIFF
--- a/python/cppyy/__init__.py
+++ b/python/cppyy/__init__.py
@@ -435,10 +435,3 @@ def multi(*bases):      # after six, see also _typemap.py
         def __new__(cls, name, this_bases, d):
             return nc_meta(name, bases, d)
     return type.__new__(faux_meta, 'faux_meta', (), {})
-
-
-#- workaround (TODO: may not be needed with Clang9) --------------------------
-if 'win32' in sys.platform:
-    cppdef("""template<>
-    std::basic_ostream<char, std::char_traits<char>>& __cdecl std::endl<char, std::char_traits<char>>(
-        std::basic_ostream<char, std::char_traits<char>>&);""")


### PR DESCRIPTION
I extended my ROOT synchronization PR to now also update the Python part of cppyy, and the only problem was this Windows workaround that caused all tests to fail (both 32 and 64 bit):
https://github.com/root-project/root/pull/14507#issuecomment-1990223500

I guess it's not needed anymore with the current LLVM version used in ROOT and cppyy?

Let's see if the tests in the sync PR are green now on Windows (besides a handful failures related to CPyCppyy that I still need to figure out).