### PR TITLE
cppyy/doc enhancements

### DIFF
--- a/doc/source/repositories.rst
+++ b/doc/source/repositories.rst
@@ -140,12 +140,11 @@ is very similar::
 Just like ``cppyy-cling``, ``CPyCppyy`` has ``cmake`` scripts which are the
 recommended way for development, as incremental builds are faster::
 
- $ mkdir build
  $ cmake ../CPyCppyy
  $ make -j <N>
 
-then simply point the ``PYTHONPATH`` envar to the `build` directory above to
-pick up the local `cppyy.so` module.
+then simply point the ``PYTHONPATH`` envar to the CPyCppyy `root` directory above to
+pick up the local `cppyy.so` module(or `libcppyy.so` module on Linux).
 
 Finally, the top-level package ``cppyy``::
 


### PR DESCRIPTION
While building the project, I noticed the following points that needs to be addressed in the documentation to avoid any confusions.

- We do not need to create `$ mkdir build` directory again because it already gets created during the previous steps. 

- Local module `libcppyy.so` exists in `root` directory of CPyCppyy not in `build` directory.