### PR TITLE
Add missing header file to test/advancedcpp.h

### DIFF
--- a/test/advancedcpp.h
+++ b/test/advancedcpp.h
@@ -2,7 +2,7 @@
 #include <ostream>
 #include <string>
 #include <vector>
-
+#include <cstdint>
 
 //===========================================================================
 #define DECLARE_DEFAULTERS(type, tname)                                     \


### PR DESCRIPTION
Building tests shows the following errors.
System info:
- Python 3.12.3
- gcc (Ubuntu 13.2.0-23ubuntu4) 13.2.0

### Steps to reproduce

1. `cd cppyy/test`
2. Run `make all`

### Expected

Builds successfully

### Found

```
(venv) trinity@ukiyo:~/compres/cppyy/test$ make all
genreflex advancedcpp.h --selection=advancedcpp.xml --rootmap=advancedcppDict.rootmap --rootmap-lib=[[advancedcppDict.so](http://advancedcppdict.so/)](http://advancedcppdict.so/)
In file included from input_line_7:3:
./advancedcpp.h:330:5: error: unknown type name 'intptr_t'
intptr_t gime_address_ptr(void* obj) {
^
./advancedcpp.h:334:5: error: unknown type name 'intptr_t'
intptr_t gime_address_ptr_ptr(void** obj) {
^
./advancedcpp.h:338:5: error: unknown type name 'intptr_t'
intptr_t gime_address_ptr_ref(void*& obj) {
^
./advancedcpp.h:342:12: error: unknown type name 'intptr_t'
static intptr_t set_address_ptr_ptr(void** obj) {
^
./advancedcpp.h:347:12: error: unknown type name 'intptr_t'
static intptr_t set_address_ptr_ref(void*& obj) {
^
./advancedcpp.h:331:17: error: use of undeclared identifier 'intptr_t'
return (intptr_t)obj;
^
./advancedcpp.h:335:17: error: use of undeclared identifier 'intptr_t'
return (intptr_t)*((long**)obj);
^
./advancedcpp.h:339:17: error: use of undeclared identifier 'intptr_t'
return (intptr_t)obj;
^
./advancedcpp.h:343:12: error: use of undeclared identifier 'intptr_t'
(*(intptr_t**)obj) = (intptr_t*)0x4321;
^
./advancedcpp.h:343:22: error: expected expression
(*(intptr_t**)obj) = (intptr_t*)0x4321;
^
./advancedcpp.h:343:31: error: use of undeclared identifier 'intptr_t'
(*(intptr_t**)obj) = (intptr_t*)0x4321;
^
./advancedcpp.h:343:40: error: expected expression
(*(intptr_t**)obj) = (intptr_t*)0x4321;
^
Error: rootcling: compilation failure (./advancedcpp_rflxc933b38e1e_dictUmbrella.h)
make: *** [Makefile:31: advancedcpp_rflx.cpp] Error 1
```
### Possible fix

Add `cstdint` header file on top of `test/advancedcpp.h` file.
