### PR TITLE
Fix search box in documentation

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -29,7 +29,9 @@ import shlex
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = []
+extensions = [
+    'sphinx_rtd_theme',
+]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']


### PR DESCRIPTION
Without listing 'sphinx_rtd_theme' in extensions, _static/jquery.js was missing and the search did not work.
(https://sphinx-rtd-theme.readthedocs.io/en/stable/installing.html)