### PR TITLE
Add regression test for unnamed enums

### DIFF
--- a/test/test_regression.py
+++ b/test/test_regression.py
@@ -1335,3 +1335,19 @@ class TestREGRESSION:
             raise # rethrow the exception
         finally:
             cppyy._backend.SetMemoryPolicy(old_memory_policy)
+
+    def test45_unnamed_enum_values(self):
+        """Ensure correct values for unnamed enums"""
+
+        import cppyy
+
+        cppyy.cppdef("""\
+        enum {
+            kSingleKey     = 1,
+            kOverwrite     = 2,
+            kWriteDelete   = 4,
+        }; """)
+
+        assert cppyy.gbl.kSingleKey == 1
+        assert cppyy.gbl.kOverwrite == 2
+        assert cppyy.gbl.kWriteDelete == 4


### PR DESCRIPTION
Regression test for a potential future issue after LLVM18 upgrade.

Corresponding PR: https://github.com/wlav/CPyCppyy/pull/29