### PR TITLE
update tests to be independent of implementation

### DIFF
--- a/test/test_pythonization.py
+++ b/test/test_pythonization.py
@@ -54,13 +54,24 @@ class TestClassPYTHONIZATION:
 
         assert cppyy.gbl.pyzables.SomeDummy2.test == 3
 
+        cppyy.cppdef("""
+            namespace pyzables {
+                class TObjString {
+                public:
+                    std::string s;
+                    TObjString(std::string ss) : s(ss) {}
+                    size_t Sizeof() { return s.size() + 1; }
+                };
+            }
+        """)
+        
         def root_pythonizor(klass, name):
-            if name == 'CppyyLegacy::TObjString':
+            if name == 'pyzables::TObjString':
                 klass.__len__ = klass.Sizeof
 
         cppyy.py.add_pythonization(root_pythonizor)
 
-        assert len(cppyy.gbl.CppyyLegacy.TObjString("aap")) == 4     # include '\0'
+        assert len(cppyy.gbl.pyzables.TObjString("aap")) == 4     # include '\0'
 
     def test01_size_mapping(self):
         """Use composites to map GetSize() onto buffer returns"""

--- a/test/test_regression.py
+++ b/test/test_regression.py
@@ -56,15 +56,24 @@ class TestREGRESSION:
 
         import cppyy, pydoc
 
-        assert not '__abstractmethods__' in dir(cppyy.gbl.gInterpreter)
-        assert '__class__' in dir(cppyy.gbl.gInterpreter)
+        cppyy.cppdef("""
+            namespace docs {
+            struct MyDocs {
+                void fn() {}
+            } s;
+            MyDocs *ptrDocs = &s;
+            }
+        """)
+
+        assert not '__abstractmethods__' in dir(cppyy.gbl.docs.ptrDocs)
+        assert '__class__' in dir(cppyy.gbl.docs.ptrDocs)
 
         self.__class__.helpout = []
-        pydoc.doc(cppyy.gbl.gInterpreter)
+        pydoc.doc(cppyy.gbl.docs.ptrDocs)
         helptext = ''.join(self.__class__.helpout)
-        assert 'TInterpreter' in helptext
+        assert 'MyDocs' in helptext
         assert 'CPPInstance' in helptext
-        assert 'AddIncludePath' in helptext
+        assert 'fn' in helptext
 
         cppyy.cppdef("namespace cppyy_regression_test { void iii() {}; }")
 


### PR DESCRIPTION
Remove dependencies on ROOT/CppyyLegacy in tests

---

This will help us maintain the same tests at the compiler-research's forks.

cc @aaronj0 @vgvassilev