### PR TITLE
Remove pattern class rule from selection xml (fix ROOT's #19189)

### DIFF
--- a/test/templates.xml
+++ b/test/templates.xml
@@ -36,7 +36,6 @@
   <class pattern="T_WithGreedyOverloads::*" />
 
   <namespace name="TypeReduction" />
-  <class pattern="TypeReduction::*" />
   <function pattern="TypeReduction::*" />
 
   <namespace name="FailedTypeDeducer" />


### PR DESCRIPTION
Remove unused template instance pattern rule as there are no instances to match.
This fixes https://github.com/root-project/root/issues/19189 .
@wlav this was thoroughly tested by ROOT's CI [1], https://github.com/root-project/root/pull/19202, and everything seems fine. 

Would it make sense to merge these changes in upstream cppyy?


[1] 14 configurations on 10 different Linux flavours, 4 macOS and 2 Windows configuration - all on x86, ARM and Apple silicon