### PR TITLE
Define global `N` variable in test_stltypes on the Python side

### DIFF
--- a/test/test_stltypes.py
+++ b/test/test_stltypes.py
@@ -9,6 +9,7 @@ test_dct = str(currpath.join("stltypesDict"))
 def setup_module(mod):
     setup_make("stltypes")
 
+global_n = 5
 
 # after CPython's Lib/test/seq_tests.py
 def iterfunc(seqn):
@@ -197,7 +198,7 @@ class TestSTLVECTOR:
         cls.test_dct = test_dct
         import cppyy
         cls.stltypes = cppyy.load_reflection_info(cls.test_dct)
-        cls.N = cppyy.gbl.N
+        cls.N = global_n
 
     def test01_builtin_type_vector_types(self):
         """Test access to std::vector<int>/std::vector<double>"""
@@ -1733,7 +1734,7 @@ class TestSTLDEQUE:
         cls.test_dct = test_dct
         import cppyy
         cls.stltypes = cppyy.load_reflection_info(cls.test_dct)
-        cls.N = cppyy.gbl.N
+        cls.N = global_n
 
     def test01_deque_byvalue_regression(self):
         """Return by value of a deque used to crash"""
@@ -1760,7 +1761,7 @@ class TestSTLSET:
         cls.test_dct = test_dct
         import cppyy
         cls.stltypes = cppyy.load_reflection_info(cls.test_dct)
-        cls.N = cppyy.gbl.N
+        cls.N = global_n
 
     def test01_set_iteration(self):
         """Iterate over a set"""
@@ -1853,7 +1854,7 @@ class TestSTLTUPLE:
         cls.test_dct = test_dct
         import cppyy
         cls.stltypes = cppyy.load_reflection_info(cls.test_dct)
-        cls.N = cppyy.gbl.N
+        cls.N = global_n
 
     def test01_tuple_creation_and_access(self):
         """Create tuples and access their elements"""
@@ -1943,7 +1944,7 @@ class TestSTLPAIR:
         cls.test_dct = test_dct
         import cppyy
         cls.stltypes = cppyy.load_reflection_info(cls.test_dct)
-        cls.N = cppyy.gbl.N
+        cls.N = global_n
 
     def test01_pair_pack_unpack(self):
         """Pack/unpack pairs"""


### PR DESCRIPTION
Right now, the stltypes test only works by accident if the datatypes dictionary is loaded too, because that's where one can find the `gbl.N` variable that is used by the test. To avoid this dependency, define the `N` variable on the Python side instead.

Mimics the following ROOT commit:
https://github.com/root-project/root/commit/1b41183c4dd3937fd0a709eff8cb3faf03bedcb8