### PR TITLE
Fix typo on C++ version support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -6,7 +6,7 @@ cppyy: Python-C++ bindings interface based on Cling/LLVM
 cppyy provides fully automatic, dynamic Python-C++ bindings by leveraging
 the Cling C++ interpreter and LLVM.
 It supports both PyPy (natively), CPython, and C++ language standards
-through C++20 (and parts of C++13).
+through C++20 (and parts of C++23).
 
 Details and performance are described in
 `this paper <http://cern.ch/wlav/Cppyy_LavrijsenDutta_PyHPC16.pdf>`_,


### PR DESCRIPTION
The README references a non-existent standard (C++13) which probably should have been C++23