### PR TITLE
Add unit test for overriding C++ function returning `unsigned int`

### DIFF
--- a/test/test_crossinheritance.py
+++ b/test/test_crossinheritance.py
@@ -1806,3 +1806,22 @@ class TestCROSSINHERITANCE:
         assert derived.s == "Hello"
         assert derived.t == "World"
 
+    def test39_returning_multi_keyword_types(self):
+        """Supporting dispatcher for functions that return multi-keyword types like `unsigned int`"""
+
+        import cppyy
+
+        cppyy.cppdef("""
+              class MyUIntBaseClass {
+              public:
+                 virtual ~MyUIntBaseClass() = default;
+                 virtual unsigned int give_unsigned_int() const = 0;
+              };
+
+        """)
+
+        # Compiling the dispatcher for the overridden member function used to
+        # fail because of the `unsigned int` type, whose name has two keywords.
+        class MyUIntDerivedClass( cppyy.gbl.MyUIntBaseClass ):
+            def give_unsigned_int( self ):
+                return 1


### PR DESCRIPTION
Covers https://github.com/wlav/CPyCppyy/pull/34

Corresponding ROOT PR: https://github.com/root-project/root/pull/19564