### PR TITLE
Add test for `std::tuple_element`

### DIFF
--- a/test/test_cpp11features.py
+++ b/test/test_cpp11features.py
@@ -560,3 +560,19 @@ class TestCPP11FEATURES:
 
         assert ns.call_creator(pyfunc)
 
+    def test20_tuple_element(self):
+        """
+        Check that std::tuple_element works.
+        See: https://github.com/root-project/root/issues/14232.
+        """
+
+        import cppyy
+
+        cppyy.cppdef("""
+        #include <tuple>
+        #include <string>
+        using ATuple = std::tuple<int, float, std::string, double>;
+        """)
+        from cppyy.gbl import ATuple
+
+        cppyy.gbl.std.tuple_element[1, ATuple].type


### PR DESCRIPTION
This test was introduced to `roottest` in the following commit: https://github.com/root-project/roottest/commit/c0e6d2002f9c79dbab9a48f3f5ab834c7e03f56b

It would be good to integrate it also to the `cppyy` test suite as some users wore claiming that it doesn't work with upstream cppyy: https://github.com/root-project/root/issues/14232